### PR TITLE
port番号9000の削除

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-server.port=9000


### PR DESCRIPTION
# やったこと
1. webでport8080を使用しているプロセスの削除方法を検索
2. コマンドで確認　→ 変化なし
3. eclipseにて指定していたport番号9000のコードを削除
4. アプリケーション実行
5. port番号8080で起動確認

※ 知らぬ間に「port番号8080」を削除していたみたいです